### PR TITLE
Add committer property for commit objects and tagger property for tag objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ starting from the newest one.
 ### stream.on('data', fn)
 
 For every commit, call `fn` with an object with keys `message`, `hash`, `tree`,
-`date`, `author`, `committer`.
+`date`, `author`, `committer`/`tagger`.
 
 ## Installation
 


### PR DESCRIPTION
Not all refs are commits, some are tags, which do not have a committer property. This PR Adds a committer or tagger property depending on which is available.

resolves #2 
related https://github.com/chrisdickinson/git-walk-refs/pull/2